### PR TITLE
fix: MESH-241 Upload Scans Drag & Drop Text

### DIFF
--- a/locales/en/cases.json
+++ b/locales/en/cases.json
@@ -56,7 +56,7 @@
     },
     "text": {
       "designTemplate": "Design Template",
-      "dragAndDrop": "Drag & drop folders containing intraoral scans or PLY and STL intraoral scans to create cases",
+      "dragAndDrop": "Drag & drop files or folders containing PLY or STL intraoral scans",
       "or": "or",
       "processUploads": "Process",
       "scansHaveIssues": "{{count}} scans have issues",

--- a/locales/en/cases.json
+++ b/locales/en/cases.json
@@ -56,7 +56,7 @@
     },
     "text": {
       "designTemplate": "Design Template",
-      "dragAndDrop": "Drag and drop folders containing intraoral scans",
+      "dragAndDrop": "Drag & drop folders containing intraoral scans or PLY and STL intraoral scans to create cases",
       "or": "or",
       "processUploads": "Process",
       "scansHaveIssues": "{{count}} scans have issues",


### PR DESCRIPTION
As part of [MESH-241](https://asiga.atlassian.net/browse/MESH-241?atlOrigin=eyJpIjoiMGQ0ZTAwZWVmNjdlNDVjZDk4ODA2ODAxYzczZmI4OTYiLCJwIjoiaiJ9) the upload drag-and-drop text needs to include:
- an ampersand instead of 'and'
- Folders or Files, rather than just Folders
- Accepted scan types (PLY & STL)

Feel free to suggest better wording if you can think of anything more concise.

[MESH-241]: https://asiga.atlassian.net/browse/MESH-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ