### PR TITLE
fix: MESH-491 Scan Issues 

### DIFF
--- a/locales/en/cases.json
+++ b/locales/en/cases.json
@@ -118,7 +118,7 @@
       "hoverDragAndDrop": "Drop case folders or intraoral scans to create designs",
       "or": "or",
       "processUploads": "Process",
-      "scansHaveIssues_one": "{{count}} scans have issues",
+      "scansHaveIssues_one": "{{count}} scan has issues",
       "scansHaveIssues_other": "{{count}} scans have issues",
       "title": "Upload Scans"
     }


### PR DESCRIPTION
Fixed a singular vs plural typo for [MESH-491](https://asiga.atlassian.net/browse/MESH-491?atlOrigin=eyJpIjoiZGEwOGQ1ZTU0YzljNGI2MWEyYjI1NDNmMGUwMmQ5YjgiLCJwIjoiaiJ9)

[MESH-491]: https://asiga.atlassian.net/browse/MESH-491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ