### PR TITLE
feat: adds toast translations for MESH 485

### DIFF
--- a/locales/en/cases.json
+++ b/locales/en/cases.json
@@ -111,7 +111,9 @@
     "failedToGenerateZip": "Failed to generate the zip file",
     "statusUpdateFailed": "Failed to change case status to downloaded",
     "statusUpdatedToDownloaded": "Case {{caseName}} moved from designed to downloaded",
-    "unableToDownloadFiles": "Unable to download files"
+    "unableToDownloadFiles": "Unable to download files",
+    "allCasesNotReadyToDownload": "The selected cases are not ready for download",
+    "someCasesNotReadyToDownload": "Some of the selected cases are not ready for download"
   },
   "uploadModal": {
     "multipleScans": {


### PR DESCRIPTION
Adds the toast translations for MESH 485. Note that the translation "allCasesNotReadyToDownload" is very likely redundant since we disable the download button in this case -- however, the code to handle this is still there and so this translation is added here. 