### PR TITLE
fix: remove unused user roles

### DIFF
--- a/locales/en-au/users.json
+++ b/locales/en-au/users.json
@@ -35,11 +35,8 @@
     "userPageInfo": "The users in your organisation are shown on this page"
   },
   "role": {
-    "accountant": "Accountant",
     "admin": "Admin",
-    "designer": "Designer",
     "owner": "Owner",
-    "technician": "Technician",
     "user": "User"
   },
   "title": {


### PR DESCRIPTION
Removed the unused roles as part of [MESH-840](https://github.com/Zydex/genira/pull/376) refactor.

**Removed**: Accountant, Designer, Technician
**Remaining**: Owner, Admin, User

Relates to: [Genira PR-376](https://github.com/Zydex/genira/pull/376)

[MESH-840]: https://asiga.atlassian.net/browse/MESH-840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ