### PR TITLE
feat: add none option to textStyle translations

### DIFF
--- a/locales/en-au/template.json
+++ b/locales/en-au/template.json
@@ -58,7 +58,8 @@
     },
     "textStyle": {
       "embossed": "Embossed",
-      "engraved": "Engraved"
+      "engraved": "Engraved",
+      "none": "None"
     }
   },
   "placeholder": {


### PR DESCRIPTION
## Summary
- Adds a `"none": "None"` translation key under `options.textStyle` in the en-au template namespace, used when no text style is applied to a case.

## Test plan
- [x] Verify the new key appears correctly in the en-au locale JSON
- [x] Confirm no existing keys were modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)